### PR TITLE
Intersection fix

### DIFF
--- a/src/intersection.c
+++ b/src/intersection.c
@@ -67,7 +67,7 @@ uint32_t* intersection_uint32(uint32_t* list_a, uint32_t* list_b){
         }
     }
 
-    list_c[it] = 0;
+    list_c[0] = it;
 
     return list_c;
 }


### PR DESCRIPTION
Hey Guillaume,

I noticed that the return array from the `intersection_uint32` method always had a size of 0, and after inspecting the code I saw why. From what I understand the variable `it` in that method should reflect the size of the returned array, hence the fix that I'm proposing.

Thanks,
Cole